### PR TITLE
Move Dependencies to Support Build Process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs2",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {
@@ -15,9 +15,7 @@
     "url": "https://github.com/EOSIO/eosjs2.git"
   },
   "dependencies": {
-    "eosjs-ecc": "^4.0.1"
-  },
-  "devDependencies": {
+    "eosjs-ecc": "^4.0.1",
     "babel-cli": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
@@ -25,7 +23,9 @@
     "@types/node": "^10.3.1",
     "json-loader": "^0.5.7",
     "ts-loader": "^4.3.1",
-    "typescript": "^2.9.1",
+    "typescript": "^2.9.1"
+  },
+  "devDependencies": {
     "webpack": "^4.11.0",
     "webpack-cli": "^3.0.2"
   }


### PR DESCRIPTION
When `yarn add`ing or `npm install`ing into a project, the `build` script should be automatically triggered. This isn't running properly on all machines. It appears to be due to the fact that many of the build dependencies are left in devDependencies. This moves those to dependencies.