### PR TITLE
Split sign and broadcast transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Library for talking to the eos api.
 
     (async () => {
         try {
-            let result = await api.pushTransaction({
+            let result = await api.signAndPushTransaction({
                 blocksBehind: 3,
                 expireSeconds: 10,
                 actions: [{
@@ -64,7 +64,7 @@ const api = new eosjs2.Api({ rpc, signatureProvider });
 
 (async () => {
     try {
-        const result = await api.pushTransaction({
+        const result = await api.signAndPushTransaction({
             blocksBehind: 3,
             expireSeconds: 10,
             actions: [{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs2",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { Abi, GetInfoResult, JsonRpc } from './eosjs2-jsonrpc';
+import { Abi, GetInfoResult, JsonRpc, PushTransactionArgs } from './eosjs2-jsonrpc';
 import * as ser from './eosjs2-serialize';
 const transactionAbi = require('../src/transaction.abi.json');
 
@@ -93,26 +93,41 @@ export class Api {
         }));
     }
 
-    async pushTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
-        let info: GetInfoResult;
-        if (!this.chainId) {
-            info = await this.rpc.get_info();
-            this.chainId = info.chain_id;
-        }
-        if (blocksBehind !== undefined && expireSeconds !== undefined) {
-            if (!info)
-                info = await this.rpc.get_info();
-            let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
-            transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
-        }
-        transaction = { ...transaction, actions: await this.serializeActions(actions) };
-        let serializedTransaction = this.serializeTransaction(transaction);
-        let availableKeys = await this.signatureProvider.getAvailableKeys();
-        let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
-        let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction: serializedTransaction });
-        return await this.rpc.push_transaction({
-            signatures,
-            serializedTransaction,
-        });
+    async fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
+      let info: GetInfoResult;
+      if (!this.chainId) {
+          info = await this.rpc.get_info();
+          this.chainId = info.chain_id;
+      }
+      if (blocksBehind !== undefined && expireSeconds !== undefined) {
+          if (!info)
+              info = await this.rpc.get_info();
+          let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
+          transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
+      }
+      return { ...transaction, actions: await this.serializeActions(actions) };
+    }
+
+    async signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
+      transaction = await this.fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction });
+      let serializedTransaction = this.serializeTransaction(transaction);
+      let availableKeys = await this.signatureProvider.getAvailableKeys();
+      let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
+      let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
+      return {
+        signatures,
+        serializedTransaction,
+      };
+    }
+
+    async pushTransaction({ signatures, serializedTransaction }: PushTransactionArgs): Promise<any> {
+      return await this.rpc.push_transaction({
+          signatures,
+          serializedTransaction,
+      });
+    }
+
+    async signAndPushTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
+      return await this.pushTransaction( await this.signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }));
     }
 } // Api

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -94,40 +94,40 @@ export class Api {
     }
 
     async fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
-      let info: GetInfoResult;
-      if (!this.chainId) {
-          info = await this.rpc.get_info();
-          this.chainId = info.chain_id;
-      }
-      if (blocksBehind !== undefined && expireSeconds !== undefined) {
-          if (!info)
-              info = await this.rpc.get_info();
-          let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
-          transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
-      }
-      return { ...transaction, actions: await this.serializeActions(actions) };
+        let info: GetInfoResult;
+        if (!this.chainId) {
+            info = await this.rpc.get_info();
+            this.chainId = info.chain_id;
+        }
+        if (blocksBehind !== undefined && expireSeconds !== undefined) {
+            if (!info)
+                info = await this.rpc.get_info();
+            let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
+            transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
+        }
+        return { ...transaction, actions: await this.serializeActions(actions) };
     }
 
     async signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
-      transaction = await this.fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction });
-      let serializedTransaction = this.serializeTransaction(transaction);
-      let availableKeys = await this.signatureProvider.getAvailableKeys();
-      let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
-      let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
-      return {
-        signatures,
-        serializedTransaction,
-      };
+        transaction = await this.fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction });
+        let serializedTransaction = this.serializeTransaction(transaction);
+        let availableKeys = await this.signatureProvider.getAvailableKeys();
+        let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
+        let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
+        return {
+            signatures,
+            serializedTransaction,
+        };
     }
 
     async pushTransaction({ signatures, serializedTransaction }: PushTransactionArgs): Promise<any> {
-      return await this.rpc.push_transaction({
-          signatures,
-          serializedTransaction,
-      });
+        return await this.rpc.push_transaction({
+            signatures,
+            serializedTransaction,
+        });
     }
 
-    async signAndPushTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
-      return await this.pushTransaction( await this.signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }));
+    async signAndPushTransaction(transaction: any) {
+        return await this.pushTransaction(await this.signTransaction(transaction));
     }
 } // Api

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -108,8 +108,7 @@ export class Api {
         return { ...transaction, actions: await this.serializeActions(actions) };
     }
 
-    async signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
-        transaction = await this.fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction });
+    async signTransaction(transaction: any) {
         let serializedTransaction = this.serializeTransaction(transaction);
         let availableKeys = await this.signatureProvider.getAvailableKeys();
         let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
@@ -120,14 +119,7 @@ export class Api {
         };
     }
 
-    async pushTransaction({ signatures, serializedTransaction }: PushTransactionArgs): Promise<any> {
-        return await this.rpc.push_transaction({
-            signatures,
-            serializedTransaction,
-        });
-    }
-
     async signAndPushTransaction(transaction: any) {
-        return await this.pushTransaction(await this.signTransaction(transaction));
+        return await this.rpc.push_transaction(await this.signTransaction(await this.fillTaposFields(transaction)));
     }
 } // Api


### PR DESCRIPTION
Warning: breaking change

- Split pushTransaction into three steps: fillTaposFields, signTransaction, and pushTransaction
- rename pushTransaction to signAndPushTransaction (pushTransaction now expects an object with signatures and a serialized transaction)
- bump version number from 0.0.4 to 0.0.5 due to breaking changes