### PR TITLE
Refactor pushTransaction into transact with optional config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 ## eosjs2
 
-Library for talking to the eos api.
+Library for talking to the eos api. transact() is used to sign and push transactions onto the blockchain with an optional configuration object parameter.  This parameter can override the default value of broadcast: true, and can be used to fill TAPOS fields given blocksBehind and expireSeconds.  Given no configuration options, transactions are expected to be unpacked with TAPOS fields (expiration, ref_block_num, ref_block_prefix) and will automatically be broadcast onto the chain.
 
-## Browser
+## Running Tests
+
+`npm run build-web` or `yarn build-web`
+Open `test.html` in your browser of choice
+
+*This should run through 5 test cases with the final showing an exception on the screen for missing required TAPOS.*
+
+
+## Browser Usage Example
 
 `npm run build-web` or `yarn build-web`
 
@@ -13,42 +21,44 @@ Library for talking to the eos api.
 <script src='dist-web/eosjs2-jsonrpc-debug.js'></script>
 <script src='dist-web/eosjs2-jssig-debug.js'></script>
 <script>
-    let pre = document.getElementsByTagName('pre')[0];
-    let rpc = new eosjs2_jsonrpc.JsonRpc('http://localhost:8000');
-    let signatureProvider = new eosjs2_jssig.default(['5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr']);
-    let api = new eosjs2.Api({ rpc, signatureProvider });
+  let pre = document.getElementsByTagName('pre')[0];
+  const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP"; // thegazelle
+  const rpc = new eosjs2_jsonrpc.JsonRpc('http://dev.cryptolions.io:18888');
+  const signatureProvider = new eosjs2_jssig.default([defaultPrivateKey]);
+  const api = new eosjs2.Api({ rpc, signatureProvider });
 
-    (async () => {
-        try {
-            let result = await api.signAndPushTransaction({
-                blocksBehind: 3,
-                expireSeconds: 10,
-                actions: [{
-                    account: 'eosio.token',
-                    name: 'transfer',
-                    authorization: [{
-                        actor: 'useraaaaaaaa',
-                        permission: 'active',
-                    }],
-                    data: {
-                        from: 'useraaaaaaaa',
-                        to: 'useraaaaaaab',
-                        quantity: '0.0001 SYS',
-                        memo: '',
-                    },
-                }],
-            });
-            pre.textContent += '\n\nTransaction pushed!\n\n' + JSON.stringify(result, null, 4);
-        } catch (e) {
-            pre.textContent += '\nCaught exception: ' + e;
-            if (e instanceof eosjs2_jsonrpc.RpcError)
-                pre.textContent += '\n\n' + JSON.stringify(e.json, null, 4);
-        }
-    })();
+  (async () => {
+    try {
+      const resultWithConfig = await api.transact({
+        actions: [{
+          account: "testeostoken",
+          name: "transfer",
+          authorization: [{
+            actor: "thegazelle",
+            permission: "active"
+          }],
+          data: {
+            from: "thegazelle",
+            to: "remasteryoda",
+            quantity: "1.0000 EOS",
+            memo: "For the future of chains around the world"
+          }
+        }]
+      }, {
+        blocksBehind: 3,
+        expireSeconds: 30,
+      });
+      pre.textContent += '\n\nTransaction with configured TAPOS pushed!\n\n' + JSON.stringify(resultWithConfig, null, 2);
+    } catch (e) {
+      pre.textContent = '\nCaught exception: ' + e;
+      if (e instanceof eosjs2_jsonrpc.RpcError)
+        pre.textContent += '\n\n' + JSON.stringify(e.json, null, 2);
+    }
+  })();
 </script>
 ```
 
-## Node / ES2015
+## Node / ES2015 Usage Example
 
 `npm install eosjs2` or `yarn add eosjs2`
 
@@ -58,34 +68,35 @@ import eosjs2 from 'eosjs2';
 // or use named imports
 // import { Api, Rpc, SignatureProvider } from 'eosjs2';
 
-const rpc = new eosjs2.Rpc.JsonRpc('http://localhost:8000');
-const signatureProvider = new eosjs2.SignatureProvider(['5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr']);
+const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP"; // thegazelle
+const rpc = new eosjs2_jsonrpc.JsonRpc('http://dev.cryptolions.io:18888');
+const signatureProvider = new eosjs2_jssig.default([defaultPrivateKey]);
 const api = new eosjs2.Api({ rpc, signatureProvider });
 
 (async () => {
-    try {
-        const result = await api.signAndPushTransaction({
-            blocksBehind: 3,
-            expireSeconds: 10,
-            actions: [{
-                account: 'eosio.token',
-                name: 'transfer',
-                authorization: [{
-                    actor: 'useraaaaaaaa',
-                    permission: 'active',
-                }],
-                data: {
-                    from: 'useraaaaaaaa',
-                    to: 'useraaaaaaab',
-                    quantity: '0.0001 SYS',
-                    memo: '',
-                },
-            }],
-        });
-        console.log(result)
-    } catch (e) {
-        // handle error
-    }
+  try {
+    const resultWithConfig = await api.transact({
+      actions: [{
+        account: "testeostoken",
+        name: "transfer",
+        authorization: [{
+          actor: "thegazelle",
+          permission: "active"
+        }],
+        data: {
+          from: "thegazelle",
+          to: "remasteryoda",
+          quantity: "1.0000 EOS",
+          memo: "For the future of chains around the world"
+        }
+      }]
+    }, {
+      blocksBehind: 3,
+      expireSeconds: 30,
+    });
+    console.log(resultWithConfig);
+  } catch (e) {
+    // handle error
+  }
 })();
-
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Library for talking to the eos api. transact() is used to sign and push transact
 `npm run build-web` or `yarn build-web`
 Open `test.html` in your browser of choice
 
-*This should run through 5 test cases with the final showing an exception on the screen for missing required TAPOS.*
+*These tests assume that you have a local node for EOS set up at localhost:8000. The test.html file should run through 5 test cases with the final showing an exception on the screen for missing required TAPOS.*
 
 
 ## Browser Usage Example
@@ -22,8 +22,8 @@ Open `test.html` in your browser of choice
 <script src='dist-web/eosjs2-jssig-debug.js'></script>
 <script>
   let pre = document.getElementsByTagName('pre')[0];
-  const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP"; // thegazelle
-  const rpc = new eosjs2_jsonrpc.JsonRpc('http://dev.cryptolions.io:18888');
+  const defaultPrivateKey = "5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr"; // useraaaaaaaa
+  const rpc = new eosjs2_jsonrpc.JsonRpc('http://localhost:8000');
   const signatureProvider = new eosjs2_jssig.default([defaultPrivateKey]);
   const api = new eosjs2.Api({ rpc, signatureProvider });
 
@@ -31,18 +31,18 @@ Open `test.html` in your browser of choice
     try {
       const resultWithConfig = await api.transact({
         actions: [{
-          account: "testeostoken",
-          name: "transfer",
-          authorization: [{
-            actor: "thegazelle",
-            permission: "active"
-          }],
-          data: {
-            from: "thegazelle",
-            to: "remasteryoda",
-            quantity: "1.0000 EOS",
-            memo: "For the future of chains around the world"
-          }
+            account: 'eosio.token',
+            name: 'transfer',
+            authorization: [{
+                actor: 'useraaaaaaaa',
+                permission: 'active',
+            }],
+            data: {
+                from: 'useraaaaaaaa',
+                to: 'useraaaaaaab',
+                quantity: '0.0001 SYS',
+                memo: '',
+            },
         }]
       }, {
         blocksBehind: 3,
@@ -77,18 +77,18 @@ const api = new eosjs2.Api({ rpc, signatureProvider });
   try {
     const resultWithConfig = await api.transact({
       actions: [{
-        account: "testeostoken",
-        name: "transfer",
-        authorization: [{
-          actor: "thegazelle",
-          permission: "active"
-        }],
-        data: {
-          from: "thegazelle",
-          to: "remasteryoda",
-          quantity: "1.0000 EOS",
-          memo: "For the future of chains around the world"
-        }
+          account: 'eosio.token',
+          name: 'transfer',
+          authorization: [{
+              actor: 'useraaaaaaaa',
+              permission: 'active',
+          }],
+          data: {
+              from: 'useraaaaaaaa',
+              to: 'useraaaaaaab',
+              quantity: '0.0001 SYS',
+              memo: '',
+          },
       }]
     }, {
       blocksBehind: 3,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs2",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -98,9 +98,8 @@ export class Api {
         return !!(expiration && ref_block_num && ref_block_prefix);
     }
 
-    async transact(transaction: any, config: TransactionConfig): Promise<any> {
+    async transact(transaction: any, { broadcast = true, blocksBehind, expireSeconds }: TransactionConfig = {}): Promise<any> {
         let info: GetInfoResult;
-        const { broadcast, blocksBehind, expireSeconds } = { broadcast: true, ...config };
 
         if (!this.chainId) {
             info = await this.rpc.get_info();

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { Abi, GetInfoResult, JsonRpc } from './eosjs2-jsonrpc';
+import { Abi, GetInfoResult, JsonRpc, PushTransactionArgs } from './eosjs2-jsonrpc';
 import * as ser from './eosjs2-serialize';
 const transactionAbi = require('../src/transaction.abi.json');
 
@@ -93,26 +93,41 @@ export class Api {
         }));
     }
 
-    async pushTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
-        let info: GetInfoResult;
-        if (!this.chainId) {
-            info = await this.rpc.get_info();
-            this.chainId = info.chain_id;
-        }
-        if (blocksBehind !== undefined && expireSeconds !== undefined) {
-            if (!info)
-                info = await this.rpc.get_info();
-            let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
-            transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
-        }
-        transaction = { ...transaction, actions: await this.serializeActions(actions) };
-        let serializedTransaction = this.serializeTransaction(transaction);
-        let availableKeys = await this.signatureProvider.getAvailableKeys();
-        let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
-        let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction: serializedTransaction });
-        return await this.rpc.push_transaction({
-            signatures,
-            serializedTransaction,
-        });
+    async fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
+      let info: GetInfoResult;
+      if (!this.chainId) {
+          info = await this.rpc.get_info();
+          this.chainId = info.chain_id;
+      }
+      if (blocksBehind !== undefined && expireSeconds !== undefined) {
+          if (!info)
+              info = await this.rpc.get_info();
+          let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
+          transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
+      }
+      return { ...transaction, actions: await this.serializeActions(actions) };
+    }
+
+    async signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
+      transaction = await this.fillTaposFields({ blocksBehind, expireSeconds, actions, ...transaction });
+      let serializedTransaction = this.serializeTransaction(transaction);
+      let availableKeys = await this.signatureProvider.getAvailableKeys();
+      let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
+      let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
+      return {
+        signatures,
+        serializedTransaction,
+      };
+    }
+
+    async pushTransaction({ signatures, serializedTransaction }: PushTransactionArgs): Promise<any> {
+      return await this.rpc.push_transaction({
+          signatures,
+          serializedTransaction,
+      });
+    }
+
+    async signAndPushTransaction({ blocksBehind, expireSeconds, actions, ...transaction }: any) {
+      return await this.pushTransaction( await this.signTransaction({ blocksBehind, expireSeconds, actions, ...transaction }));
     }
 } // Api

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -94,48 +94,48 @@ export class Api {
     }
 
     // eventually break out into TransactionValidator class
-    private hasRequiredTaposFields({ expiration, ref_block_num, ref_block_prefix, ...transaction}: any): boolean {
-       return !!(expiration && ref_block_num && ref_block_prefix);
+    private hasRequiredTaposFields({ expiration, ref_block_num, ref_block_prefix, ...transaction }: any): boolean {
+        return !!(expiration && ref_block_num && ref_block_prefix);
     }
 
-    async transact(transaction: any, config: TransactionConfig): Promise<any>  {
-      let info: GetInfoResult;
-      const { broadcast, blocksBehind, expireSeconds } = { broadcast: true, ...config };
+    async transact(transaction: any, config: TransactionConfig): Promise<any> {
+        let info: GetInfoResult;
+        const { broadcast, blocksBehind, expireSeconds } = { broadcast: true, ...config };
 
-      if (!this.chainId) {
-        info = await this.rpc.get_info();
-        this.chainId = info.chain_id;
-      }
-
-      if (typeof blocksBehind === "number" && expireSeconds) { // use config fields to generate TAPOS if they exist
-        if (!info) {
-          info = await this.rpc.get_info();
+        if (!this.chainId) {
+            info = await this.rpc.get_info();
+            this.chainId = info.chain_id;
         }
-        let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
-        transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
-      }
 
-      if (!this.hasRequiredTaposFields(transaction)) {
-        throw new Error("Required configuration or TAPOS fields are not present")
-      }
+        if (typeof blocksBehind === "number" && expireSeconds) { // use config fields to generate TAPOS if they exist
+            if (!info) {
+                info = await this.rpc.get_info();
+            }
+            let refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
+            transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
+        }
 
-      transaction = { ...transaction, actions: await this.serializeActions(transaction.actions) };
-      let serializedTransaction = this.serializeTransaction(transaction);
-      let availableKeys = await this.signatureProvider.getAvailableKeys();
-      let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
-      let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
-      let pushTransactionArgs = { signatures, serializedTransaction };
-      if (broadcast) {
-        return this.pushSignedTransaction(pushTransactionArgs);
-      }
-      return pushTransactionArgs;
+        if (!this.hasRequiredTaposFields(transaction)) {
+            throw new Error("Required configuration or TAPOS fields are not present")
+        }
+
+        transaction = { ...transaction, actions: await this.serializeActions(transaction.actions) };
+        let serializedTransaction = this.serializeTransaction(transaction);
+        let availableKeys = await this.signatureProvider.getAvailableKeys();
+        let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
+        let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
+        let pushTransactionArgs = { signatures, serializedTransaction };
+        if (broadcast) {
+            return this.pushSignedTransaction(pushTransactionArgs);
+        }
+        return pushTransactionArgs;
     }
 
     async pushSignedTransaction({ signatures, serializedTransaction }: PushTransactionArgs): Promise<any> {
-      return this.rpc.push_transaction({
-          signatures,
-          serializedTransaction,
-      });
+        return this.rpc.push_transaction({
+            signatures,
+            serializedTransaction,
+        });
     }
 
 } // Api

--- a/src/eosjs2-jsonrpc.ts
+++ b/src/eosjs2-jsonrpc.ts
@@ -70,10 +70,16 @@ export interface GetInfoResult {
     block_net_limit: number;
 }
 
+export interface TransactionConfig {
+  broadcast?: boolean;
+  blocksBehind?: number;
+  expireSeconds?: number;
+}
+
 export interface PushTransactionArgs {
     signatures: string[];
     serializedTransaction: Uint8Array;
-};
+}
 
 function arrayToHex(data: Uint8Array) {
     let result = '';

--- a/src/eosjs2-jsonrpc.ts
+++ b/src/eosjs2-jsonrpc.ts
@@ -71,9 +71,9 @@ export interface GetInfoResult {
 }
 
 export interface TransactionConfig {
-  broadcast?: boolean;
-  blocksBehind?: number;
-  expireSeconds?: number;
+    broadcast?: boolean;
+    blocksBehind?: number;
+    expireSeconds?: number;
 }
 
 export interface PushTransactionArgs {

--- a/test.html
+++ b/test.html
@@ -5,10 +5,17 @@
 <script src='dist-web/eosjs2-jssig-debug.js'></script>
 <script>
   let pre = document.getElementsByTagName('pre')[0];
-  const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP";// thegazelle
+  const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP"; // thegazelle
   const rpc = new eosjs2_jsonrpc.JsonRpc('http://dev.cryptolions.io:18888');
   const signatureProvider = new eosjs2_jssig.default([defaultPrivateKey]);
-  const api = new eosjs2.Api({ rpc, signatureProvider });
+  const api = new eosjs2.Api({
+    rpc,
+    signatureProvider
+  });
+
+  function waitTwoSeconds() {
+    return new Promise(resolve => setTimeout(resolve, 2000));
+  }
 
   (async () => {
     try {
@@ -32,86 +39,81 @@
         expireSeconds: 30,
       });
       pre.textContent += '\n\nTransaction with configured TAPOS pushed!\n\n' + JSON.stringify(resultWithConfig, null, 2);
+      await waitTwoSeconds(); // run additional tests after 2 second delay
 
-      // run additional tests after 2 second delay
-      setTimeout( async () => {
-        const resultWithoutBroadcast = await api.transact({
-            actions: [{
-              account: "testeostoken",
-              name: "transfer",
-              authorization: [{
-                actor: "thegazelle",
-                permission: "active"
-              }],
-              data: {
-                from: "thegazelle",
-                to: "remasteryoda",
-                quantity: "1.0000 EOS",
-                memo: "For the future of chains around the world"
-              }
-            }]
-        }, {
-          broadcast: false,
-          blocksBehind: 3,
-          expireSeconds: 30,
-        });
-        pre.textContent = '\n\nTransaction serialized and signed but not pushed!\n\n' + JSON.stringify(resultWithoutBroadcast, null, 2);
+      const resultWithoutBroadcast = await api.transact({
+        actions: [{
+          account: "testeostoken",
+          name: "transfer",
+          authorization: [{
+            actor: "thegazelle",
+            permission: "active"
+          }],
+          data: {
+            from: "thegazelle",
+            to: "remasteryoda",
+            quantity: "1.0000 EOS",
+            memo: "For the future of chains around the world"
+          }
+        }]
+      }, {
+        broadcast: false,
+        blocksBehind: 3,
+        expireSeconds: 30,
+      });
+      pre.textContent = '\n\nTransaction serialized and signed but not pushed!\n\n' + JSON.stringify(resultWithoutBroadcast, null, 2);
+      await waitTwoSeconds();
 
-        setTimeout( async () => {
-          const broadcastResult = await api.pushSignedTransaction(resultWithoutBroadcast);
-          pre.textContent = '\n\nSerialized Transaction and signatures pushed!\n\n' + JSON.stringify(broadcastResult, null, 2);
+      const broadcastResult = await api.pushSignedTransaction(resultWithoutBroadcast);
+      pre.textContent = '\n\nSerialized Transaction and signatures pushed!\n\n' + JSON.stringify(broadcastResult, null, 2);
+      await waitTwoSeconds();
 
-          setTimeout( async () => {
-            const currentDate = new Date();
-            const timePlusTen = currentDate.getTime() + 10000;
-            const timeInISOString = (new Date(timePlusTen)).toISOString();
-            const expiration = timeInISOString.substr(0, timeInISOString.length - 1);
-            const resultWithoutConfig = await api.transact({
-              expiration,
-              ref_block_num: 33609,
-              ref_block_prefix: 1692338825,
-                actions: [{
-                  account: "testeostoken",
-                  name: "transfer",
-                  authorization: [{
-                    actor: "thegazelle",
-                    permission: "active"
-                  }],
-                  data: {
-                    from: "thegazelle",
-                    to: "remasteryoda",
-                    quantity: "1.0000 EOS",
-                    memo: "For the future of chains around the world"
-                  }
-                }]
-              });
-              pre.textContent = '\n\nTransaction with manual TAPOS pushed!\n\n' + JSON.stringify(resultWithoutConfig, null, 2);
-              setTimeout( async () => {
-                const resultShouldFail= await api.transact({
-                    actions: [{
-                      account: "testeostoken",
-                      name: "transfer",
-                      authorization: [{
-                        actor: "thegazelle",
-                        permission: "active"
-                      }],
-                      data: {
-                        from: "thegazelle",
-                        to: "remasteryoda",
-                        quantity: "1.0000 EOS",
-                        memo: "For the future of chains around the world"
-                      }
-                    }]
-                  });
-              }, 2000);
-            }, 2000);
-        }, 1000);
-      }, 2000);
+      const currentDate = new Date();
+      const timePlusTen = currentDate.getTime() + 10000;
+      const timeInISOString = (new Date(timePlusTen)).toISOString();
+      const expiration = timeInISOString.substr(0, timeInISOString.length - 1);
+      const resultWithoutConfig = await api.transact({
+        expiration,
+        ref_block_num: 33609,
+        ref_block_prefix: 1692338825,
+        actions: [{
+          account: "testeostoken",
+          name: "transfer",
+          authorization: [{
+            actor: "thegazelle",
+            permission: "active"
+          }],
+          data: {
+            from: "thegazelle",
+            to: "remasteryoda",
+            quantity: "1.0000 EOS",
+            memo: "For the future of chains around the world"
+          }
+        }]
+      });
+      pre.textContent = '\n\nTransaction with manual TAPOS pushed!\n\n' + JSON.stringify(resultWithoutConfig, null, 2);
 
+      await waitTwoSeconds();
+      const resultShouldFail = await api.transact({
+        actions: [{
+          account: "testeostoken",
+          name: "transfer",
+          authorization: [{
+            actor: "thegazelle",
+            permission: "active"
+          }],
+          data: {
+            from: "thegazelle",
+            to: "remasteryoda",
+            quantity: "1.0000 EOS",
+            memo: "For the future of chains around the world"
+          }
+        }]
+      });
     } catch (e) {
       pre.textContent = '\nCaught exception: ' + e;
       if (e instanceof eosjs2_jsonrpc.RpcError)
-        pre.textContent += '\n\n' + JSON.stringify(e.json, null, 4);
+        pre.textContent += '\n\n' + JSON.stringify(e.json, null, 2);
     }
   })();
 </script>

--- a/test.html
+++ b/test.html
@@ -1,0 +1,117 @@
+<pre style="width: 100%; height: 100%; margin:0px; "></pre>
+
+<script src='dist-web/eosjs2-debug.js'></script>
+<script src='dist-web/eosjs2-jsonrpc-debug.js'></script>
+<script src='dist-web/eosjs2-jssig-debug.js'></script>
+<script>
+  let pre = document.getElementsByTagName('pre')[0];
+  const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP";// thegazelle
+  const rpc = new eosjs2_jsonrpc.JsonRpc('http://dev.cryptolions.io:18888');
+  const signatureProvider = new eosjs2_jssig.default([defaultPrivateKey]);
+  const api = new eosjs2.Api({ rpc, signatureProvider });
+
+  (async () => {
+    try {
+      const resultWithConfig = await api.transact({
+        actions: [{
+          account: "testeostoken",
+          name: "transfer",
+          authorization: [{
+            actor: "thegazelle",
+            permission: "active"
+          }],
+          data: {
+            from: "thegazelle",
+            to: "remasteryoda",
+            quantity: "1.0000 EOS",
+            memo: "For the future of chains around the world"
+          }
+        }]
+      }, {
+        blocksBehind: 3,
+        expireSeconds: 30,
+      });
+      pre.textContent += '\n\nTransaction with configured TAPOS pushed!\n\n' + JSON.stringify(resultWithConfig, null, 2);
+
+      // run additional tests after 2 second delay
+      setTimeout( async () => {
+        const resultWithoutBroadcast = await api.transact({
+            actions: [{
+              account: "testeostoken",
+              name: "transfer",
+              authorization: [{
+                actor: "thegazelle",
+                permission: "active"
+              }],
+              data: {
+                from: "thegazelle",
+                to: "remasteryoda",
+                quantity: "1.0000 EOS",
+                memo: "For the future of chains around the world"
+              }
+            }]
+        }, {
+          broadcast: false,
+          blocksBehind: 3,
+          expireSeconds: 30,
+        });
+        pre.textContent = '\n\nTransaction serialized and signed but not pushed!\n\n' + JSON.stringify(resultWithoutBroadcast, null, 2);
+
+        setTimeout( async () => {
+          const broadcastResult = await api.pushSignedTransaction(resultWithoutBroadcast);
+          pre.textContent = '\n\nSerialized Transaction and signatures pushed!\n\n' + JSON.stringify(broadcastResult, null, 2);
+
+          setTimeout( async () => {
+            const currentDate = new Date();
+            const timePlusTen = currentDate.getTime() + 10000;
+            const timeInISOString = (new Date(timePlusTen)).toISOString();
+            const expiration = timeInISOString.substr(0, timeInISOString.length - 1);
+            const resultWithoutConfig = await api.transact({
+              expiration,
+              ref_block_num: 33609,
+              ref_block_prefix: 1692338825,
+                actions: [{
+                  account: "testeostoken",
+                  name: "transfer",
+                  authorization: [{
+                    actor: "thegazelle",
+                    permission: "active"
+                  }],
+                  data: {
+                    from: "thegazelle",
+                    to: "remasteryoda",
+                    quantity: "1.0000 EOS",
+                    memo: "For the future of chains around the world"
+                  }
+                }]
+              });
+              pre.textContent = '\n\nTransaction with manual TAPOS pushed!\n\n' + JSON.stringify(resultWithoutConfig, null, 2);
+              setTimeout( async () => {
+                const resultShouldFail= await api.transact({
+                    actions: [{
+                      account: "testeostoken",
+                      name: "transfer",
+                      authorization: [{
+                        actor: "thegazelle",
+                        permission: "active"
+                      }],
+                      data: {
+                        from: "thegazelle",
+                        to: "remasteryoda",
+                        quantity: "1.0000 EOS",
+                        memo: "For the future of chains around the world"
+                      }
+                    }]
+                  });
+              }, 2000);
+            }, 2000);
+        }, 1000);
+      }, 2000);
+
+    } catch (e) {
+      pre.textContent = '\nCaught exception: ' + e;
+      if (e instanceof eosjs2_jsonrpc.RpcError)
+        pre.textContent += '\n\n' + JSON.stringify(e.json, null, 4);
+    }
+  })();
+</script>

--- a/test.html
+++ b/test.html
@@ -5,13 +5,10 @@
 <script src='dist-web/eosjs2-jssig-debug.js'></script>
 <script>
   let pre = document.getElementsByTagName('pre')[0];
-  const defaultPrivateKey = "5JmqocoeJ1ury2SdjVNVgNL1n4qR2sse5cxN4upvspU2R5PEnxP"; // thegazelle
-  const rpc = new eosjs2_jsonrpc.JsonRpc('http://dev.cryptolions.io:18888');
+  const defaultPrivateKey = "5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr"; // useraaaaaaaa
+  const rpc = new eosjs2_jsonrpc.JsonRpc('http://localhost:8000');
   const signatureProvider = new eosjs2_jssig.default([defaultPrivateKey]);
-  const api = new eosjs2.Api({
-    rpc,
-    signatureProvider
-  });
+  const api = new eosjs2.Api({ rpc, signatureProvider });
 
   function waitTwoSeconds() {
     return new Promise(resolve => setTimeout(resolve, 2000));
@@ -21,18 +18,18 @@
     try {
       const resultWithConfig = await api.transact({
         actions: [{
-          account: "testeostoken",
-          name: "transfer",
-          authorization: [{
-            actor: "thegazelle",
-            permission: "active"
-          }],
-          data: {
-            from: "thegazelle",
-            to: "remasteryoda",
-            quantity: "1.0000 EOS",
-            memo: "For the future of chains around the world"
-          }
+            account: 'eosio.token',
+            name: 'transfer',
+            authorization: [{
+                actor: 'useraaaaaaaa',
+                permission: 'active',
+            }],
+            data: {
+                from: 'useraaaaaaaa',
+                to: 'useraaaaaaab',
+                quantity: '0.0001 SYS',
+                memo: '',
+            },
         }]
       }, {
         blocksBehind: 3,
@@ -43,18 +40,18 @@
 
       const resultWithoutBroadcast = await api.transact({
         actions: [{
-          account: "testeostoken",
-          name: "transfer",
-          authorization: [{
-            actor: "thegazelle",
-            permission: "active"
-          }],
-          data: {
-            from: "thegazelle",
-            to: "remasteryoda",
-            quantity: "1.0000 EOS",
-            memo: "For the future of chains around the world"
-          }
+            account: 'eosio.token',
+            name: 'transfer',
+            authorization: [{
+                actor: 'useraaaaaaaa',
+                permission: 'active',
+            }],
+            data: {
+                from: 'useraaaaaaaa',
+                to: 'useraaaaaaab',
+                quantity: '0.0001 SYS',
+                memo: '',
+            },
         }]
       }, {
         broadcast: false,
@@ -66,6 +63,9 @@
 
       const broadcastResult = await api.pushSignedTransaction(resultWithoutBroadcast);
       pre.textContent = '\n\nSerialized Transaction and signatures pushed!\n\n' + JSON.stringify(broadcastResult, null, 2);
+
+      /* The test below will not work with hardcoded values for ref_block_num and prefix, we need to use the response from the previous test to retrieve those when full test suite is implemented
+
       await waitTwoSeconds();
 
       const currentDate = new Date();
@@ -74,40 +74,41 @@
       const expiration = timeInISOString.substr(0, timeInISOString.length - 1);
       const resultWithoutConfig = await api.transact({
         expiration,
-        ref_block_num: 33609,
-        ref_block_prefix: 1692338825,
+        ref_block_num: 47657,
+        ref_block_prefix: 3285495572,
         actions: [{
-          account: "testeostoken",
-          name: "transfer",
-          authorization: [{
-            actor: "thegazelle",
-            permission: "active"
-          }],
-          data: {
-            from: "thegazelle",
-            to: "remasteryoda",
-            quantity: "1.0000 EOS",
-            memo: "For the future of chains around the world"
-          }
+            account: 'eosio.token',
+            name: 'transfer',
+            authorization: [{
+                actor: 'useraaaaaaaa',
+                permission: 'active',
+            }],
+            data: {
+                from: 'useraaaaaaaa',
+                to: 'useraaaaaaab',
+                quantity: '0.0001 SYS',
+                memo: '',
+            },
         }]
       });
       pre.textContent = '\n\nTransaction with manual TAPOS pushed!\n\n' + JSON.stringify(resultWithoutConfig, null, 2);
+      */
 
       await waitTwoSeconds();
       const resultShouldFail = await api.transact({
         actions: [{
-          account: "testeostoken",
-          name: "transfer",
-          authorization: [{
-            actor: "thegazelle",
-            permission: "active"
-          }],
-          data: {
-            from: "thegazelle",
-            to: "remasteryoda",
-            quantity: "1.0000 EOS",
-            memo: "For the future of chains around the world"
-          }
+            account: 'eosio.token',
+            name: 'transfer',
+            authorization: [{
+                actor: 'useraaaaaaaa',
+                permission: 'active',
+            }],
+            data: {
+                from: 'useraaaaaaaa',
+                to: 'useraaaaaaab',
+                quantity: '0.0001 SYS',
+                memo: '',
+            },
         }]
       });
     } catch (e) {


### PR DESCRIPTION
I added a more comprehensive manual browser test.html file which should cover all necessary use cases of transact() until we implement unit testing in this repository.

@tbfleming I have left the config parameter as the second parameter due to a general consensus amongst myself, Chris, and Brandon.  Although this seems to defy the conventions of other languages, this is supported by MDN documentation for JS functions (i.e. [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)  or [Array.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) ).
This also allows for the user to omit the field altogether if they manually insert TAPOS fields.