### PR TITLE
Add prepublish script, reduce package size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "eosjs2",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {
+    "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc -p ./tsconfig.node.json && babel dist --out-dir dist",
     "build-web": "webpack"
@@ -15,17 +16,17 @@
     "url": "https://github.com/EOSIO/eosjs2.git"
   },
   "dependencies": {
-    "eosjs-ecc": "^4.0.1",
+    "eosjs-ecc": "^4.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^10.3.1",
     "babel-cli": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-stage-1": "^6.24.1",
-    "@types/node": "^10.3.1",
     "json-loader": "^0.5.7",
     "ts-loader": "^4.3.1",
-    "typescript": "^2.9.1"
-  },
-  "devDependencies": {
+    "typescript": "^2.9.1",
     "webpack": "^4.11.0",
     "webpack-cli": "^3.0.2"
   }


### PR DESCRIPTION
Learning more about how npm works. 😝 

Packages should be built locally using build dependencies from `devDependencies` and then pushed up to npm.

In this way, packages come pre-built when `npm install`ing, and without all the bloat of those build tools.