### PR TITLE
Expose API methods for getting ABI(s).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs2",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Allow consumers of the eosjs2 API to retrieve ABIs and Ricardian contracts.