### PR TITLE
Pass transaction ABIs to SignatureProvider when signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs2",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/eosjs2-api.ts
+++ b/src/eosjs2-api.ts
@@ -21,6 +21,7 @@ export interface SignatureProviderArgs {
   chainId: string;
   requiredKeys: string[];
   serializedTransaction: Uint8Array;
+  abis: Abi[];
 }
 
 export interface SignatureProvider {
@@ -155,14 +156,15 @@ export class Api {
     }
 
     if (!this.hasRequiredTaposFields(transaction)) {
-      throw new Error("Required configuration or TAPOS fields are not present")
+      throw new Error("Required configuration or TAPOS fields are not present");
     }
 
+    let abis: Abi[] = await this.getTransactionAbis(transaction);
     transaction = { ...transaction, actions: await this.serializeActions(transaction.actions) };
     let serializedTransaction = this.serializeTransaction(transaction);
     let availableKeys = await this.signatureProvider.getAvailableKeys();
     let requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
-    let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction });
+    let signatures = await this.signatureProvider.sign({ chainId: this.chainId, requiredKeys, serializedTransaction, abis });
     let pushTransactionArgs = { signatures, serializedTransaction };
     if (broadcast) {
       return this.pushSignedTransaction(pushTransactionArgs);


### PR DESCRIPTION
Custom signature providers may want to use ABIs. For example, a signature provider may want to display a Ricardian contract to a user without going to the chain and getting it itself. In this PR, we pass ABIs to the signature provider during signing.

Prior to this PR, the API's `transact()` method (during action serialization) was already calling out to get ABIs for each action in the transaction. Now, we do that step before the actions are serialized and pass those ABIs along when signing. There's no added network overhead. In fact, in some cases, there is less overhead.

For example, prior to this PR, if a transaction had multiples of the same action and the given contract was not previously cached, the contract for the given action (and, as a result, the abi) would be fetched multiple times. Now, it's guaranteed to only be fetched once and is then cached.

