### PR TITLE
Expose implementations for use with node

### DIFF
--- a/src/eosjs2-serialize.ts
+++ b/src/eosjs2-serialize.ts
@@ -745,26 +745,26 @@ export function transactionHeader(refBlock: BlockTaposInfo, expireSeconds: numbe
   };
 };
 
-export function serializeActionData(contract: Contract, account: string, name: string, data: any): string {
+export function serializeActionData(contract: Contract, account: string, name: string, data: any, textEncoder: TextEncoder, textDecoder: TextDecoder): string {
   let action = contract.actions.get(name);
   if (!action) {
     throw new Error(`Unknown action ${name} in contract ${account}`);
   }
-  let buffer = new SerialBuffer;
+  let buffer = new SerialBuffer({ textEncoder, textDecoder });
   action.serialize(buffer, data);
   return arrayToHex(buffer.asUint8Array());
 }
 
-export function serializeAction(contract: Contract, account: string, name: string, authorization: Authorization[], data: any): SerializedAction {
+export function serializeAction(contract: Contract, account: string, name: string, authorization: Authorization[], data: any, textEncoder: TextEncoder, textDecoder: TextDecoder): SerializedAction {
   return {
     account,
     name,
     authorization,
-    data: serializeActionData(contract, account, name, data),
+    data: serializeActionData(contract, account, name, data, textEncoder, textDecoder),
   };
 }
 
-export function deserializeActionData(contract: Contract, account: string, name: string, data: any): any {
+export function deserializeActionData(contract: Contract, account: string, name: string, data: any, textEncoder: TextEncoder, textDecoder: TextDecoder): any {
   const action = contract.actions.get(name);
   if (typeof data === "string") {
     data = hexToUint8Array(data)
@@ -772,16 +772,16 @@ export function deserializeActionData(contract: Contract, account: string, name:
   if (!action) {
     throw new Error(`Unknown action ${name} in contract ${account}`);
   }
-  let buffer = new SerialBuffer;
+  let buffer = new SerialBuffer({ textDecoder, textEncoder });
   buffer.pushArray(data)
   return action.deserialize(buffer);
 }
 
-export function deserializeAction(contract: Contract, account: string, name: string, authorization: Authorization[], data: any): Action {
+export function deserializeAction(contract: Contract, account: string, name: string, authorization: Authorization[], data: any, textEncoder: TextEncoder, textDecoder: TextDecoder): Action {
   return {
     account,
     name,
     authorization,
-    data: deserializeActionData(contract, account, name, data),
+    data: deserializeActionData(contract, account, name, data, textEncoder, textDecoder),
   };
 }


### PR DESCRIPTION
This is necessary to substitute the TextEncoder/TextDecoder for use with nodejs. The Api must be extended and `serializeTransaction` and `deserializeTransaction` overwritten.

```
import { Api, SerialBuffer } from "eosjs2"
import { TextDecoder, TextEncoder } from "text-encoding"

export class MyEosjsApi extends Api {
  public serializeTransaction(transaction: any): Uint8Array {
    const textEncoder = new TextEncoder()
    const textDecoder = new TextDecoder()
    const buffer = new SerialBuffer({ textEncoder, textDecoder })
    this.serialize(buffer, "transaction", {
      max_net_usage_words: 0,
      max_cpu_usage_ms: 0,
      delay_sec: 0,
      context_free_actions: [],
      actions: [],
      transaction_extensions: [],
      ...transaction,
    })
    return buffer.asUint8Array()
  }

  public deserializeTransaction(transaction: Uint8Array): any {
    const textEncoder = new TextEncoder()
    const textDecoder = new TextDecoder()
    const buffer = new SerialBuffer({ textEncoder, textDecoder })
    buffer.pushArray(transaction)
    return this.deserialize(buffer, "transaction")
  }
}
```