### PR TITLE
Updating version to 1.0.0 (breaking change) for release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs2",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
SignatureProviders now receive ABIs in binary. This is a breaking change. After merging, I'll tag the commit as a new release, documenting the breaking change, and publish on `npm`.